### PR TITLE
Adds example of dependent attributes

### DIFF
--- a/lib/rest_easy/types.rb
+++ b/lib/rest_easy/types.rb
@@ -20,6 +20,18 @@ module RestEasy
         end
       end
 
+      def required( options )
+        stub = options.delete( :stub )
+
+        @options[ :required ] = true
+        @options[ :stub ] = stub if stub
+      end
+
+      def controls( attribute, *conditions )
+        @options[ :controls ] = attribute
+        @options[ :control_conditions ] = conditions
+      end
+
       def method_missing( name, *values )
         @options[ name ] = case values.length
         when 0

--- a/spec/rest_easy/exemplars/User.rb
+++ b/spec/rest_easy/exemplars/User.rb
@@ -1,20 +1,31 @@
+DiscountTypes = RestEasy::Types::Strict::String.enum( 'AMOUNT', 'PERCENT' )
+
 class User < RestEasy::Model
   attribute :id, RestEasy::Types.new( Integer ) {
     unique_id
   }
 
   attribute :first_name, RestEasy::Types.new( String ) {
-    stub ''
-    required
+    required stub: ''
     searchable
     whatever 1, 'arg', :foo
   }
 
   attribute :last_name, RestEasy::Types.new( String ) {
-    stub ''
     is :required, :searchable
+    stub ''
     whatever 1, 'arg', :foo
   }
+
+  attribute :discount_type, RestEasy::Types.new( DiscountTypes ) {
+    on_change -> instance, new_value {
+
+    }
+  }
+
+  attribute :discount, RestEasy::Types.new( Float ) {
+
+  }.constrained(gteq: 0.0, lteq: 100.0)
 
   attribute :avatar, RestEasy::Types.new( String )
 end


### PR DESCRIPTION
An example of how we could handle dependent attributes, like the validation of `discount`/`discount_type` for Fortnox.

Since we have started to experiment with `dry-validations` instead of `dry-types` for validation and casting this can be left as an illustration until we decide what approach to use.